### PR TITLE
refactor(envited.ascs.digital): Fix showDialog default state

### DIFF
--- a/apps/envited.ascs.digital/modules/Users/UsersDialogConfirm.tsx
+++ b/apps/envited.ascs.digital/modules/Users/UsersDialogConfirm.tsx
@@ -15,7 +15,7 @@ interface DialogConfirmProps {
 export const UserDialogConfirm: FC<DialogConfirmProps> = ({ id }) => {
   const { t } = useTranslation('Users')
   const { error, success } = useNotification()
-  const [showDialog, setShowDialog] = useState(true)
+  const [showDialog, setShowDialog] = useState(false)
 
   const deleteUserWithId = (id: string) => async () => {
     try {


### PR DESCRIPTION
# Scope
Dialog is open on loading users page

# Definition of done
Dialog should be only open when click on the delete button
