### PR TITLE
feat(envited.ascs.digital): Replace Buy button with Contact Sales

### DIFF
--- a/apps/envited.ascs.digital/modules/Asset/Asset.tsx
+++ b/apps/envited.ascs.digital/modules/Asset/Asset.tsx
@@ -356,7 +356,7 @@ export const Asset = () => {
                     href={product.href}
                     className="whitespace-nowrap text-sm font-medium text-blue-900 hover:text-blue-800"
                   >
-                    View all
+                    View
                     <span aria-hidden="true"> &rarr;</span>
                   </a>
                 </div>

--- a/apps/envited.ascs.digital/modules/Assets/Assets.tsx
+++ b/apps/envited.ascs.digital/modules/Assets/Assets.tsx
@@ -223,7 +223,7 @@ export const Assets = () => {
                       href={product.href}
                       className="whitespace-nowrap text-sm font-medium text-blue-900 hover:text-blue-800"
                     >
-                      View all
+                      View
                       <span aria-hidden="true"> &rarr;</span>
                     </a>
                   </div>

--- a/apps/envited.ascs.digital/modules/Assets/DashboardAssets.tsx
+++ b/apps/envited.ascs.digital/modules/Assets/DashboardAssets.tsx
@@ -66,7 +66,7 @@ export const DashboardAssets = () => {
                   href={product.href}
                   className="whitespace-nowrap text-sm font-medium text-blue-900 hover:text-blue-800"
                 >
-                  View all
+                  View
                   <span aria-hidden="true"> &rarr;</span>
                 </a>
               </div>

--- a/apps/envited.ascs.digital/modules/Member/Member.tsx
+++ b/apps/envited.ascs.digital/modules/Member/Member.tsx
@@ -224,7 +224,7 @@ export const Member: FC<MemberProps> = ({ member }) => {
                     href={product.href}
                     className="whitespace-nowrap text-sm font-medium text-blue-900 hover:text-blue-800"
                   >
-                    View all
+                    View
                     <span aria-hidden="true"> &rarr;</span>
                   </a>
                 </div>


### PR DESCRIPTION
# Work done
Buy button on the asset detail page should be replaced by Contact sales. With opening a prefilled email on a new tab.

Closes #294 