### PR TITLE
refactor(envited.ascs.digital): use the raw encoder instead of json

### DIFF
--- a/apps/envited.ascs.digital/common/asset/validateAndCreateMetadata.utils.integration.test.ts
+++ b/apps/envited.ascs.digital/common/asset/validateAndCreateMetadata.utils.integration.test.ts
@@ -1,0 +1,80 @@
+import { createFilename } from './validateAndCreateMetadata.utils'
+
+describe('common/asset/validateAndCreateMetadata.utils', () => {
+  describe('createFilename', () => {
+    it('should create a valid CID from a byte array', async () => {
+      // Create a sample byte array
+      const testData = new TextEncoder().encode('Hello, World!')
+
+      // Generate CID
+      const cid = await createFilename(testData)
+
+      // Verify the result is a valid CID string
+      expect(cid).toBeDefined()
+      expect(typeof cid).toBe('string')
+      expect(cid).toMatch(/^bafkr/) // CID v1 with raw codec starts with 'bafkr'
+    })
+
+    it('should create consistent CIDs for identical content', async () => {
+      const data1 = new TextEncoder().encode('Same content')
+      const data2 = new TextEncoder().encode('Same content')
+
+      const cid1 = await createFilename(data1)
+      const cid2 = await createFilename(data2)
+
+      expect(cid1).toBe(cid2)
+    })
+
+    it('should create different CIDs for different content', async () => {
+      const data1 = new TextEncoder().encode('Content 1')
+      const data2 = new TextEncoder().encode('Content 2')
+
+      const cid1 = await createFilename(data1)
+      const cid2 = await createFilename(data2)
+
+      expect(cid1).not.toBe(cid2)
+    })
+
+    it('should handle empty byte array', async () => {
+      const emptyData = new Uint8Array(0)
+
+      const cid = await createFilename(emptyData)
+
+      expect(cid).toBeDefined()
+      expect(typeof cid).toBe('string')
+    })
+
+    it('should handle large byte arrays', async () => {
+      // Create a larger byte array (100KB)
+      const largeData = new Uint8Array(102400).fill(1)
+
+      const cid = await createFilename(largeData)
+
+      expect(cid).toBeDefined()
+      expect(typeof cid).toBe('string')
+    })
+
+    it('should create the same CID as pinata', async () => {
+      // Create a sample byte array
+      const testData = new TextEncoder().encode(
+        JSON.stringify({
+          name: 'did:web:registry.gaia-x.eu:HdMap:wDgNY3gZAxMe3LjhdAZ9TbPiYnQ-yybNhCu8',
+          symbol: 'ENVITED',
+          decimals: 2,
+          shouldPreferSymbol: true,
+          thumbnailUri: 'THUMBNAIL_UR',
+          attributes: [],
+          assets: [],
+        }),
+      )
+
+      // Generate CID
+      const cid = await createFilename(testData)
+
+      // Verify the result is a valid CID string
+      expect(cid).toBeDefined()
+      expect(typeof cid).toBe('string')
+      expect(cid).toMatch('bafkreigdlsyni2wjmihwrotlmhficmbnspltfiuwbo476e7x45eojntzha') // CID v1 with raw codec starts with 'bafkr'
+    })
+  })
+})

--- a/apps/envited.ascs.digital/common/asset/validateAndCreateMetadata.utils.test.ts
+++ b/apps/envited.ascs.digital/common/asset/validateAndCreateMetadata.utils.test.ts
@@ -6,7 +6,7 @@ describe('common/asset/validateAndCreateMetadata.utils', () => {
     it('should create a filename', async () => {
       const byteArray = 'BYTE_ARRAY'
 
-      const jsonStub = {
+      const rawStub = {
         encode: jest.fn().mockReturnValue('JSON_BYTES'),
         code: 'JSON_CODE',
       } as any
@@ -22,12 +22,12 @@ describe('common/asset/validateAndCreateMetadata.utils', () => {
       } as any
 
       const result = await SUT._createFilename({
-        json: jsonStub,
+        raw: rawStub,
         sha256: sha256Stub,
         CID: CIDStub,
       })(byteArray as any)
 
-      expect(jsonStub.encode).toHaveBeenCalledWith('BYTE_ARRAY')
+      expect(rawStub.encode).toHaveBeenCalledWith('BYTE_ARRAY')
       expect(CIDStub.create).toHaveBeenCalledWith(1, 'JSON_CODE', 'SHA256_HASH')
       expect(result).toBe('CID')
     })
@@ -200,7 +200,6 @@ describe('common/asset/validateAndCreateMetadata.utils', () => {
         },
       ]
 
-      const byteArray = 'BYTE_ARRAY' as any
       const getFilenameFromFileStub = jest.fn().mockResolvedValue({
         buffer: 'FILE_BUFFER',
         cid: 'FILE_CID',

--- a/apps/envited.ascs.digital/common/asset/validateAndCreateMetadata.utils.ts
+++ b/apps/envited.ascs.digital/common/asset/validateAndCreateMetadata.utils.ts
@@ -1,5 +1,5 @@
 import { CID } from 'multiformats/cid'
-import * as json from 'multiformats/codecs/json'
+import * as raw from 'multiformats/codecs/raw'
 import { Hasher } from 'multiformats/dist/src/hashes/hasher'
 import { sha256 } from 'multiformats/hashes/sha2'
 import {
@@ -21,15 +21,15 @@ import {
 } from 'ramda'
 
 import { extractFromByteArray, read } from '../archive'
-import { ExtractedFile, ExtractedFileWithCID, Manifest, ManifestLink } from './types'
+import { ExtractedFileWithCID, Manifest, ManifestLink } from './types'
 
 export const _createFilename =
-  ({ json, sha256, CID }: { json: any; sha256: Hasher<'sha2-256', 18>; CID: any }) =>
+  ({ raw, sha256, CID }: { raw: any; sha256: Hasher<'sha2-256', 18>; CID: any }) =>
   async (byteArray: any) => {
     try {
-      const jsonBytes = json.encode(byteArray)
-      const hash = await sha256.digest(jsonBytes)
-      const cid = CID.create(1, json.code, hash)
+      const rawBytes = raw.encode(byteArray)
+      const hash = await sha256.digest(rawBytes)
+      const cid = CID.create(1, raw.code, hash)
 
       return cid.toString()
     } catch (error: unknown) {
@@ -38,7 +38,7 @@ export const _createFilename =
   }
 
 export const createFilename = _createFilename({
-  json,
+  raw,
   sha256,
   CID,
 })

--- a/apps/envited.ascs.digital/jest.config.ts
+++ b/apps/envited.ascs.digital/jest.config.ts
@@ -19,7 +19,10 @@ export default {
     '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': '@nx/react/plugins/jest',
     '^.+\\.[tj]sx?$': ['babel-jest', { presets: ['@nx/next/babel'] }],
   },
-  transformIgnorePatterns: [`/node_modules/(?!(${esModules})/*)`],
+  transformIgnorePatterns: [`/node_modules/(?!(${esModules})/.*)`],
+  moduleNameMapper: {
+    '^multiformats/(.*)$': '<rootDir>/../../node_modules/multiformats/dist/src/$1',
+  },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/apps/envited.ascs.digital',
 }


### PR DESCRIPTION
# Scope

We were using the json encoder to generate cids, pinata seems to be using raw.
This pr refactors using json to raw

# Work done
- Refactor the code
- Update unit test
- Add integration test