### PR TITLE
feat(envited-x-data-space): Update validation amount of files

### DIFF
--- a/apps/envited-x-data-space/common/validator/shacl/shacl.constants.ts
+++ b/apps/envited-x-data-space/common/validator/shacl/shacl.constants.ts
@@ -18,4 +18,4 @@ export const SCHEMA_MAP = {
 
 export const CONTEXT_DROP_SCHEMAS = [Schema.sh, Schema.skos, Schema.xsd]
 
-export const AMOUNT_OF_UNDEFINED_FILES_IN_MANIFEST = 2
+export const AMOUNT_OF_UNDEFINED_FILES_IN_MANIFEST = 1

--- a/apps/envited-x-data-space/common/validator/shacl/shacl.test.ts
+++ b/apps/envited-x-data-space/common/validator/shacl/shacl.test.ts
@@ -24,7 +24,7 @@ describe('common/validator/shacl', () => {
         amount: 12,
       })
 
-      const countAmountOfFilesInZipStub = jest.fn().mockResolvedValue(14)
+      const countAmountOfFilesInZipStub = jest.fn().mockResolvedValue(13)
 
       // then ... we should get a valid response
       const result = await SUT._validateShaclFile({

--- a/apps/envited-x-data-space/common/validator/shacl/shacl.ts
+++ b/apps/envited-x-data-space/common/validator/shacl/shacl.ts
@@ -15,7 +15,7 @@ import {
   formatFilesErrorMessage,
   loadDataset,
   parseStreamToDataset,
-  subtractManifestAndReadMeFiles,
+  subtractManifestFile,
   validateShacl,
 } from './shacl.utils'
 
@@ -59,7 +59,7 @@ export const _validateShaclFile =
       }
 
       const amountOfFilesInZip = await countAmountOfFilesInZip(file)
-      const amountWithoutManifestAndReadme = subtractManifestAndReadMeFiles(amountOfFilesInZip)
+      const amountWithoutManifestAndReadme = subtractManifestFile(amountOfFilesInZip)
 
       if (!equals(amountWithoutManifestAndReadme)(manifestFiles.amount)) {
         return {

--- a/apps/envited-x-data-space/common/validator/shacl/shacl.utils.test.ts
+++ b/apps/envited-x-data-space/common/validator/shacl/shacl.utils.test.ts
@@ -75,8 +75,8 @@ describe('common/validator/shacl/shacl.utils', () => {
     expect(result).toEqual(expected)
   })
 
-  describe('subtractManifestAndReadMeFiles', () => {
-    const result = SUT.subtractManifestAndReadMeFiles(16)
+  describe('subtractManifestFile', () => {
+    const result = SUT.subtractManifestFile(15)
 
     expect(result).toEqual(14)
   })

--- a/apps/envited-x-data-space/common/validator/shacl/shacl.utils.ts
+++ b/apps/envited-x-data-space/common/validator/shacl/shacl.utils.ts
@@ -65,4 +65,4 @@ export const formatFilesErrorMessage = (errors: { error: string }[]) =>
     (x: string) => `${ERRORS.FILES_NOT_FOUND} - ${x}`,
   )(errors)
 
-export const subtractManifestAndReadMeFiles = flip(subtract)(AMOUNT_OF_UNDEFINED_FILES_IN_MANIFEST)
+export const subtractManifestFile = flip(subtract)(AMOUNT_OF_UNDEFINED_FILES_IN_MANIFEST)


### PR DESCRIPTION
# Work done
The check with amount of files is updated without subtracting the README file.

@jdsika if you updated the example asset with the README in the linked data, you could check it. There's still a check if there is a README in the asset. To be sure there is one.

Closes #422 