### PR TITLE
445 fix cover image types

### DIFF
--- a/apps/envited-x-data-space/common/asset/constants.ts
+++ b/apps/envited-x-data-space/common/asset/constants.ts
@@ -39,6 +39,4 @@ export const MANIFEST_LINK_ACCESS_ROLE = ['manifest:hasAccessRole', '@id']
 
 export const DOMAIN_METADATA_FILE = 'metadata/domainMetadata.json'
 
-export const MEDIA_DESCRIPTOR = 'envited-x:isMedia'
-
 export const KEYWORDS = ['Has ']

--- a/apps/envited-x-data-space/common/asset/constants.ts
+++ b/apps/envited-x-data-space/common/asset/constants.ts
@@ -39,4 +39,6 @@ export const MANIFEST_LINK_ACCESS_ROLE = ['manifest:hasAccessRole', '@id']
 
 export const DOMAIN_METADATA_FILE = 'metadata/domainMetadata.json'
 
+export const MEDIA_DESCRIPTOR = 'envited-x:isMedia'
+
 export const KEYWORDS = ['Has ']

--- a/apps/envited-x-data-space/common/asset/createModifiedManifest.test.ts
+++ b/apps/envited-x-data-space/common/asset/createModifiedManifest.test.ts
@@ -15,7 +15,7 @@ describe('common/asset/createModifiedManifest', () => {
         {
           arrayBuffer: 'BUFFER',
           path: 'media/TestfeldNiedersachsen_ALKS_ODR_sample_offset_impression-01.png',
-          type: 'envited-x:isMedia',
+          category: 'envited-x:isMedia',
           cid: 'DISPLAY_CID',
         },
       ]
@@ -782,7 +782,7 @@ describe('common/asset/createModifiedManifest', () => {
         {
           arrayBuffer: 'BUFFER',
           path: 'media/TestfeldNiedersachsen_ALKS_ODR_sample_offset_impression-01.png',
-          type: 'envited-x:isMedia',
+          category: 'envited-x:isMedia',
           cid: 'DISPLAY_CID',
         },
       ]
@@ -1549,7 +1549,7 @@ describe('common/asset/createModifiedManifest', () => {
         {
           arrayBuffer: 'BUFFER',
           path: 'media/TestfeldNiedersachsen_ALKS_ODR_sample_offset_impression-01.png',
-          type: 'envited-x:isMedia',
+          category: 'envited-x:isMedia',
           cid: 'DISPLAY_CID',
         },
       ]
@@ -2316,7 +2316,7 @@ describe('common/asset/createModifiedManifest', () => {
         {
           arrayBuffer: 'BUFFER',
           path: 'media/TestfeldNiedersachsen_ALKS_ODR_sample_offset_impression-01.png',
-          type: 'envited-x:isMedia',
+          category: 'envited-x:isMedia',
           cid: 'DISPLAY_CID',
         },
       ]

--- a/apps/envited-x-data-space/common/asset/createModifiedManifest.ts
+++ b/apps/envited-x-data-space/common/asset/createModifiedManifest.ts
@@ -1,4 +1,4 @@
-import { equals, evolve, find, has, includes, map, pipe, propEq, propOr, tail } from 'ramda'
+import { equals, evolve, find, includes, map, pipe, propEq, propOr, tail } from 'ramda'
 
 import { formatAssetUri, formatIpfsUri, formatMetadataUri } from '../utils'
 import { AccessRole, ExtractedFileWithCID, ManifestCategoryId, ManifestLink } from './types'
@@ -40,8 +40,8 @@ export const modifyManifestLink =
 
 export const formatManifestUri =
   (assetCID: string, domainMetadataCID: string, visualizationFiles: ExtractedFileWithCID[]) =>
-  (accessRole: AccessRole, path: string, type: ManifestCategoryId) => {
-    if (includes(type, [ManifestCategoryId.envitedXIsMedia]) && equals(accessRole)(AccessRole.envitedXIsPublic)) {
+  (accessRole: AccessRole, path: string, category: ManifestCategoryId) => {
+    if (includes(category, [ManifestCategoryId.envitedXIsMedia]) && equals(accessRole)(AccessRole.envitedXIsPublic)) {
       return pipe(
         find(propEq(formatManifestLinkPath(path), 'path')),
         propOr('', 'cid'),
@@ -49,7 +49,7 @@ export const formatManifestUri =
       )(visualizationFiles)
     }
 
-    if (includes(type, [ManifestCategoryId.envitedXIsMetadata])) {
+    if (includes(category, [ManifestCategoryId.envitedXIsMetadata])) {
       return formatIpfsUri(domainMetadataCID)
     }
 
@@ -59,12 +59,12 @@ export const formatManifestUri =
 
     if (
       equals(accessRole)(AccessRole.envitedXIsRegistered) ||
-      (equals(accessRole)(AccessRole.envitedXIsRegistered) && equals(ManifestCategoryId.envitedXIsLicense)(type))
+      (equals(accessRole)(AccessRole.envitedXIsRegistered) && equals(ManifestCategoryId.envitedXIsLicense)(category))
     ) {
       return `${formatMetadataUri(assetCID)}${tail(path)}`
     }
 
-    if (equals(accessRole)(AccessRole.envitedXIsPublic) && equals(ManifestCategoryId.envitedXIsLicense)(type)) {
+    if (equals(accessRole)(AccessRole.envitedXIsPublic) && equals(ManifestCategoryId.envitedXIsLicense)(category)) {
       return path
     }
 

--- a/apps/envited-x-data-space/common/asset/createTokenMetadata.test.ts
+++ b/apps/envited-x-data-space/common/asset/createTokenMetadata.test.ts
@@ -89,7 +89,7 @@ describe('common/asset/createTokenMetadata', () => {
         ],
       }
 
-      const result = await SUT.createTokenMetadata({
+      const result = SUT.createTokenMetadata({
         asset: {
           cid: 'ASSET_CID',
           fileSize: 1024,
@@ -194,7 +194,7 @@ describe('common/asset/createTokenMetadata', () => {
         ],
       }
 
-      const result = await SUT.createTokenMetadata({
+      const result = SUT.createTokenMetadata({
         asset: {
           cid: 'ASSET_CID',
           fileSize: 1024,
@@ -298,7 +298,7 @@ describe('common/asset/createTokenMetadata', () => {
         ],
       }
 
-      const result = await SUT.createTokenMetadata({
+      const result = SUT.createTokenMetadata({
         asset: {
           cid: 'ASSET_CID',
           fileSize: 1024,
@@ -402,7 +402,7 @@ describe('common/asset/createTokenMetadata', () => {
         ],
       }
 
-      const result = await SUT.createTokenMetadata({
+      const result = SUT.createTokenMetadata({
         asset: {
           cid: 'ASSET_CID',
           fileSize: 1024,

--- a/apps/envited-x-data-space/common/asset/types.ts
+++ b/apps/envited-x-data-space/common/asset/types.ts
@@ -8,7 +8,7 @@ export enum ManifestCategoryId {
   envitedXIsSimulationData = 'envited-x:isSimulationData',
   envitedXIsReferencedSimulationData = 'envited-x:isReferencedSimulationData',
   envitedXIsValidationReport = 'envited-x:isValidationReport',
-  envitedXIsOwner = 'envited-x:isOwner'
+  envitedXIsOwner = 'envited-x:isOwner',
 }
 
 export enum MetadataType {
@@ -40,14 +40,14 @@ export interface Manifest {
 }
 
 export interface ManifestContext {
-  xsd: string
-  gx: string
-  skos: string
-  sh: string
-  manifest: string
-  "envited-x": string
-  hdmap: string
-  rdf: string
+  'xsd': string
+  'gx': string
+  'skos': string
+  'sh': string
+  'manifest': string
+  'envited-x': string
+  'hdmap': string
+  'rdf': string
 }
 
 export interface ManifestValue<T> {

--- a/apps/envited-x-data-space/common/asset/types.ts
+++ b/apps/envited-x-data-space/common/asset/types.ts
@@ -39,29 +39,29 @@ export interface Manifest {
   'manifest:hasReferencedArtifacts': []
 }
 
-export type ManifestContext  =
-  'automotive-simulator' |
-  'environment-model' |
-  'envited-x' |
-  'general' |
-  'georeference' |
-  'gx' |
-  'hdmap' |
-  'leakage-test' |
-  'manifest' |
-  'openlabel' |
-  'ositrace' |
-  'rdf' |
-  'scenario' |
-  'service' |
-  'sh' |
-  'simulated-sensor' |
-  'simulated-model' |
-  'skos' |
-  'surface-model' |
-  'survey' |
-  'vv-report' |
-  'xsd'
+export type ManifestContext =
+  | 'automotive-simulator'
+  | 'environment-model'
+  | 'envited-x'
+  | 'general'
+  | 'georeference'
+  | 'gx'
+  | 'hdmap'
+  | 'leakage-test'
+  | 'manifest'
+  | 'openlabel'
+  | 'ositrace'
+  | 'rdf'
+  | 'scenario'
+  | 'service'
+  | 'sh'
+  | 'simulated-sensor'
+  | 'simulated-model'
+  | 'skos'
+  | 'surface-model'
+  | 'survey'
+  | 'vv-report'
+  | 'xsd'
 
 export interface ManifestValue<T> {
   '@value': T

--- a/apps/envited-x-data-space/common/asset/types.ts
+++ b/apps/envited-x-data-space/common/asset/types.ts
@@ -8,6 +8,7 @@ export enum ManifestCategoryId {
   envitedXIsSimulationData = 'envited-x:isSimulationData',
   envitedXIsReferencedSimulationData = 'envited-x:isReferencedSimulationData',
   envitedXIsValidationReport = 'envited-x:isValidationReport',
+  envitedXIsOwner = 'envited-x:isOwner'
 }
 
 export enum MetadataType {
@@ -33,7 +34,7 @@ export interface Manifest {
   '@id': string
   '@type': string
   'manifest:hasManifestReference': ManifestLink
-  'manifest:hasLicense': ManifestLink
+  'manifest:hasLicense': ManifestLicense
   'manifest:hasArtifacts': ManifestArtifacts
   'manifest:hasReferencedArtifacts': []
 }
@@ -44,55 +45,34 @@ export interface ManifestContext {
   skos: string
   sh: string
   manifest: string
-  envited: string
+  "envited-x": string
   hdmap: string
   rdf: string
 }
 
-export interface ManifestHasAccessRole {
-  '@type': string
-  '@id': AccessRole
-}
-
-export interface ManifestHasCategory {
-  '@type': string
-  '@id': ManifestCategoryId
-}
-
-export interface ManifestFilePath {
-  '@value': string
-  '@type': string
-}
-export interface ManifestCid {
-  '@value': string
-  '@type': string
-}
-export interface ManifestMimeType {
-  '@value': string
-  '@type': string
-}
-export interface ManifestFileSize {
-  '@value': number
-  '@type': string
-}
-export interface ManifestFilename {
-  '@value': string
+export interface ManifestValue<T> {
+  '@value': T
   '@type': string
 }
 
 export interface ManifestHasFileMetadata {
   '@type': string
-  'manifest:filePath': ManifestFilePath
-  'manifest:cid': ManifestCid
-  'manifest:mimeType': ManifestMimeType
-  'manifest:fileSize': ManifestFileSize
-  'manifest:filename': ManifestFilename
+  'manifest:filePath': ManifestValue<string>
+  // 'manifest:cid': ManifestCid
+  'manifest:mimeType': ManifestValue<string>
+  'manifest:fileSize'?: ManifestValue<number>
+  'manifest:filename'?: ManifestValue<string>
+}
+
+export interface ManifestId<T> {
+  '@type': string
+  '@id': T
 }
 
 export interface ManifestLink {
   '@type': string
-  'manifest:hasAccessRole': ManifestHasAccessRole
-  'manifest:hasCategory': ManifestHasCategory
+  'manifest:hasAccessRole': ManifestId<AccessRole>
+  'manifest:hasCategory': ManifestId<ManifestCategoryId>
   'manifest:hasFileMetadata': ManifestHasFileMetadata
 }
 
@@ -100,10 +80,7 @@ export interface ManifestMetadataLink extends ManifestLink {
   'manifest:iri': {
     '@id': string
   }
-  'skos:note': {
-    '@value': string
-    '@type': string
-  }
+  'skos:note': ManifestValue<string>
   'sh:conformsTo': {
     '@id': string
   }
@@ -114,7 +91,14 @@ export interface ManifestLicense {
   'gx:license': {
     '@value': string
   }
-  'manifest:licenseData': ManifestLink
+  'manifest:licenseData': ManifestLicenseData
+}
+
+export interface ManifestLicenseData {
+  '@type': string
+  'manifest:hasAccessRole': ManifestId<AccessRole>
+  'manifest:hasCategory': ManifestId<ManifestCategoryId>
+  'manifest:hasFileMetadata': ManifestHasFileMetadata
 }
 
 export interface ExtractedFile {

--- a/apps/envited-x-data-space/common/asset/types.ts
+++ b/apps/envited-x-data-space/common/asset/types.ts
@@ -39,16 +39,29 @@ export interface Manifest {
   'manifest:hasReferencedArtifacts': []
 }
 
-export interface ManifestContext {
-  'xsd': string
-  'gx': string
-  'skos': string
-  'sh': string
-  'manifest': string
-  'envited-x': string
-  'hdmap': string
-  'rdf': string
-}
+export type ManifestContext  =
+  'automotive-simulator' |
+  'environment-model' |
+  'envited-x' |
+  'general' |
+  'georeference' |
+  'gx' |
+  'hdmap' |
+  'leakage-test' |
+  'manifest' |
+  'openlabel' |
+  'ositrace' |
+  'rdf' |
+  'scenario' |
+  'service' |
+  'sh' |
+  'simulated-sensor' |
+  'simulated-model' |
+  'skos' |
+  'surface-model' |
+  'survey' |
+  'vv-report' |
+  'xsd'
 
 export interface ManifestValue<T> {
   '@value': T
@@ -58,7 +71,6 @@ export interface ManifestValue<T> {
 export interface ManifestHasFileMetadata {
   '@type': string
   'manifest:filePath': ManifestValue<string>
-  // 'manifest:cid': ManifestCid
   'manifest:mimeType': ManifestValue<string>
   'manifest:fileSize'?: ManifestValue<number>
   'manifest:filename'?: ManifestValue<string>
@@ -104,7 +116,7 @@ export interface ManifestLicenseData {
 export interface ExtractedFile {
   arrayBuffer: ArrayBuffer
   path: string
-  type: string
+  category: ManifestCategoryId
 }
 
 export interface ExtractedFileWithCID extends ExtractedFile {

--- a/apps/envited-x-data-space/common/asset/utils.test.ts
+++ b/apps/envited-x-data-space/common/asset/utils.test.ts
@@ -2,7 +2,7 @@ import domainMetadata from '../fixtures/domainMetadata.json'
 import manifest from '../fixtures/manifest.json'
 import manifestRemoteAssetData from '../fixtures/manifestRemoteAssetData.json'
 import { ASSET_TYPE } from './constants'
-import { ManifestLink, MetadataType } from './types'
+import { ManifestCategoryId, ManifestLink, MetadataType } from './types'
 import * as SUT from './utils'
 
 describe('common/asset/utils', () => {
@@ -51,120 +51,120 @@ describe('common/asset/utils', () => {
         owner: [
           {
             path: 'simulation-data/TestfeldNiedersachsen_ALKS_ODR_sample_offset.xodr',
-            type: 'envited-x:isSimulationData',
+            category: 'envited-x:isSimulationData',
           },
         ],
         registeredUser: [
           {
             path: 'simulation-data/TestfeldNiedersachsen_ALKS_ODR_sample_offset.bjson',
-            type: 'envited-x:isMiscellaneous',
+            category: 'envited-x:isMiscellaneous',
           },
           {
             path: 'documentation/TestfeldNiedersachsen_ALKS_ODR_sample_offset_Documentation_stats.txt',
-            type: 'envited-x:isDocumentation',
+            category: 'envited-x:isDocumentation',
           },
           {
             path: 'validation-reports/TestfeldNiedersachsen_ALKS_ODR_sample_offset_asam_cb_xodr.xqar',
-            type: 'envited-x:isValidationReport',
+            category: 'envited-x:isValidationReport',
           },
           {
             path: 'validation-reports/TestfeldNiedersachsen_ALKS_ODR_sample_offset_openmsl_cb_xodr.xqar',
-            type: 'envited-x:isValidationReport',
+            category: 'envited-x:isValidationReport',
           },
           {
             path: 'media/TestfeldNiedersachsen_ALKS_ODR_sample_offset_impression-02.png',
-            type: 'envited-x:isMedia',
+            category: 'envited-x:isMedia',
             mimeType: 'image/png',
           },
           {
             path: 'media/TestfeldNiedersachsen_ALKS_ODR_sample_offset_impression-03.png',
-            type: 'envited-x:isMedia',
+            category: 'envited-x:isMedia',
             mimeType: 'image/png',
           },
           {
             path: 'media/bbox.geojson',
-            type: 'envited-x:isMedia',
+            category: 'envited-x:isMedia',
             mimeType: 'application/x-geojson',
           },
           {
             path: 'media/roadNetwork.geojson',
-            type: 'envited-x:isMedia',
+            category: 'envited-x:isMedia',
             mimeType: 'application/x-geojson',
           },
           {
             path: 'media/3d_preview/breakLines.json',
-            type: 'envited-x:isMedia',
+            category: 'envited-x:isMedia',
             mimeType: 'application/json',
           },
           {
             path: 'media/3d_preview/junctions.json',
-            type: 'envited-x:isMedia',
+            category: 'envited-x:isMedia',
             mimeType: 'application/json',
           },
           {
             path: 'media/3d_preview/laneSections.json',
-            type: 'envited-x:isMedia',
+            category: 'envited-x:isMedia',
             mimeType: 'application/json',
           },
           {
             path: 'media/3d_preview/lanes.json',
-            type: 'envited-x:isMedia',
+            category: 'envited-x:isMedia',
             mimeType: 'application/json',
           },
           {
             path: 'media/3d_preview/objects.json',
-            type: 'envited-x:isMedia',
+            category: 'envited-x:isMedia',
             mimeType: 'application/json',
           },
           {
             path: 'media/3d_preview/refLine.json',
-            type: 'envited-x:isMedia',
+            category: 'envited-x:isMedia',
             mimeType: 'application/json',
           },
           {
             path: 'media/3d_preview/roadMarks.json',
-            type: 'envited-x:isMedia',
+            category: 'envited-x:isMedia',
             mimeType: 'application/json',
           },
           {
             path: 'media/3d_preview/roads.json',
-            type: 'envited-x:isMedia',
+            category: 'envited-x:isMedia',
             mimeType: 'application/json',
           },
           {
             path: 'media/3d_preview/signals.json',
-            type: 'envited-x:isMedia',
+            category: 'envited-x:isMedia',
             mimeType: 'application/json',
           },
           {
             path: 'validation-reports/TestfeldNiedersachsen_ALKS_ODR_sample_offset_openmsl_cb_xodr_QCReport.txt',
-            type: 'envited-x:isValidationReport',
+            category: 'envited-x:isValidationReport',
           },
         ],
         publicUser: [
           {
             path: 'manifest_reference.json',
-            type: 'envited-x:isManifest',
+            category: 'envited-x:isManifest',
           },
           {
             path: 'documentation/TestfeldNiedersachsen_ALKS_ODR_sample_offset_Documentation.pdf',
-            type: 'envited-x:isDocumentation',
+            category: 'envited-x:isDocumentation',
           },
           {
             path: 'metadata/hdmap_instance.json',
-            type: 'envited-x:isMetadata',
+            category: 'envited-x:isMetadata',
           },
           {
             path: 'validation-reports/TestfeldNiedersachsen_ALKS_ODR_sample_offset_asam_cb_xodr_QCReport.txt',
-            type: 'envited-x:isValidationReport',
+            category: 'envited-x:isValidationReport',
           },
           {
             path: 'README.md',
-            type: 'envited-x:isDocumentation',
+            category: 'envited-x:isDocumentation',
           },
           {
             path: 'media/TestfeldNiedersachsen_ALKS_ODR_sample_offset_impression-01.png',
-            type: 'envited-x:isMedia',
+            category: 'envited-x:isMedia',
             mimeType: 'image/png',
           },
         ],
@@ -182,21 +182,21 @@ describe('common/asset/utils', () => {
         owner: [
           {
             path: 'PATH',
-            type: 'FILE_TYPE',
+            category: 'CATEGORY',
             buffer: 'FILE_BUFFER',
           },
         ],
         publicUser: [
           {
             path: 'PATH',
-            type: 'FILE_TYPE',
+            category: 'CATEGORY',
             buffer: 'FILE_BUFFER',
           },
         ],
         registeredUser: [
           {
             path: 'PATH',
-            type: 'FILE_TYPE',
+            category: 'CATEGORY',
             buffer: 'FILE_BUFFER',
           },
         ],
@@ -206,7 +206,7 @@ describe('common/asset/utils', () => {
       const getPathsAndBuffersFromByteArrayStub = jest.fn().mockReturnValue([
         {
           path: 'PATH',
-          type: 'FILE_TYPE',
+          category: 'CATEGORY',
           buffer: 'FILE_BUFFER',
         },
       ]) as any
@@ -224,7 +224,7 @@ describe('common/asset/utils', () => {
       const files = [
         {
           path: 'data/TestfeldNiedersachsen_ALKS_ODR_sample.xodr',
-          type: 'FILE_TYPE',
+          category: 'CATEGORY' as ManifestCategoryId,
         },
       ]
 
@@ -232,14 +232,14 @@ describe('common/asset/utils', () => {
         {
           arrayBuffer: 'FILE_BUFFER',
           path: 'data/TestfeldNiedersachsen_ALKS_ODR_sample.xodr',
-          type: 'FILE_TYPE',
+          category: 'CATEGORY' as ManifestCategoryId,
         },
       ]
 
       const byteArray = 'BYTE_ARRAY' as any
       const getFileFromByteArrayStub = jest.fn().mockResolvedValue({
         path: 'data/TestfeldNiedersachsen_ALKS_ODR_sample.xodr',
-        type: 'FILE_TYPE',
+        category: 'CATEGORY' as ManifestCategoryId,
         arrayBuffer: 'FILE_BUFFER',
       }) as any
 
@@ -256,7 +256,7 @@ describe('common/asset/utils', () => {
       const files = [
         {
           path: 'data/TestfeldNiedersachsen_ALKS_ODR_sample.xodr',
-          type: 'FILE_TYPE',
+          category: 'CATEGORY' as ManifestCategoryId,
           arrayBuffer: 'FILE_BUFFER',
         },
       ]
@@ -266,7 +266,7 @@ describe('common/asset/utils', () => {
           arrayBuffer: 'FILE_BUFFER',
           cid: 'FILE_CID',
           path: 'data/TestfeldNiedersachsen_ALKS_ODR_sample.xodr',
-          type: 'FILE_TYPE',
+          category: 'CATEGORY' as ManifestCategoryId,
         },
       ]
 
@@ -274,7 +274,7 @@ describe('common/asset/utils', () => {
         arrayBuffer: 'FILE_BUFFER',
         cid: 'FILE_CID',
         path: 'data/TestfeldNiedersachsen_ALKS_ODR_sample.xodr',
-        type: 'FILE_TYPE',
+        category: 'CATEGORY' as ManifestCategoryId,
       }) as any
 
       const result = await SUT._getAllFilenamesFromFiles({
@@ -489,7 +489,7 @@ describe('common/asset/utils', () => {
       expect(result).toEqual([
         {
           path: 'simulation-data/TestfeldNiedersachsen_ALKS_ODR_sample_offset.xodr',
-          type: 'envited-x:isSimulationData',
+          category: 'envited-x:isSimulationData',
         },
       ])
     })

--- a/apps/envited-x-data-space/common/asset/utils.test.ts
+++ b/apps/envited-x-data-space/common/asset/utils.test.ts
@@ -52,24 +52,29 @@ describe('common/asset/utils', () => {
           {
             path: 'simulation-data/TestfeldNiedersachsen_ALKS_ODR_sample_offset.xodr',
             category: 'envited-x:isSimulationData',
+            mimeType: 'application/x-xodr',
           },
         ],
         registeredUser: [
           {
             path: 'simulation-data/TestfeldNiedersachsen_ALKS_ODR_sample_offset.bjson',
             category: 'envited-x:isMiscellaneous',
+            mimeType: 'application/json',
           },
           {
             path: 'documentation/TestfeldNiedersachsen_ALKS_ODR_sample_offset_Documentation_stats.txt',
             category: 'envited-x:isDocumentation',
+            mimeType: 'text/plain',
           },
           {
             path: 'validation-reports/TestfeldNiedersachsen_ALKS_ODR_sample_offset_asam_cb_xodr.xqar',
             category: 'envited-x:isValidationReport',
+            mimeType: 'application/x-xqar',
           },
           {
             path: 'validation-reports/TestfeldNiedersachsen_ALKS_ODR_sample_offset_openmsl_cb_xodr.xqar',
             category: 'envited-x:isValidationReport',
+            mimeType: 'application/x-xqar',
           },
           {
             path: 'media/TestfeldNiedersachsen_ALKS_ODR_sample_offset_impression-02.png',
@@ -139,28 +144,34 @@ describe('common/asset/utils', () => {
           {
             path: 'validation-reports/TestfeldNiedersachsen_ALKS_ODR_sample_offset_openmsl_cb_xodr_QCReport.txt',
             category: 'envited-x:isValidationReport',
+            mimeType: 'text/plain',
           },
         ],
         publicUser: [
           {
             path: 'manifest_reference.json',
             category: 'envited-x:isManifest',
+            mimeType: 'application/ld+json',
           },
           {
             path: 'documentation/TestfeldNiedersachsen_ALKS_ODR_sample_offset_Documentation.pdf',
             category: 'envited-x:isDocumentation',
+            mimeType: 'application/pdf',
           },
           {
             path: 'metadata/hdmap_instance.json',
             category: 'envited-x:isMetadata',
+            mimeType: 'application/ld+json',
           },
           {
             path: 'validation-reports/TestfeldNiedersachsen_ALKS_ODR_sample_offset_asam_cb_xodr_QCReport.txt',
             category: 'envited-x:isValidationReport',
+            mimeType: 'text/plain',
           },
           {
             path: 'README.md',
             category: 'envited-x:isDocumentation',
+            mimeType: 'text/markdown',
           },
           {
             path: 'media/TestfeldNiedersachsen_ALKS_ODR_sample_offset_impression-01.png',
@@ -490,6 +501,7 @@ describe('common/asset/utils', () => {
         {
           path: 'simulation-data/TestfeldNiedersachsen_ALKS_ODR_sample_offset.xodr',
           category: 'envited-x:isSimulationData',
+          mimeType: 'application/x-xodr',
         },
       ])
     })

--- a/apps/envited-x-data-space/common/asset/utils.test.ts
+++ b/apps/envited-x-data-space/common/asset/utils.test.ts
@@ -74,54 +74,67 @@ describe('common/asset/utils', () => {
           {
             path: 'media/TestfeldNiedersachsen_ALKS_ODR_sample_offset_impression-02.png',
             type: 'envited-x:isMedia',
+            mimeType: 'image/png',
           },
           {
             path: 'media/TestfeldNiedersachsen_ALKS_ODR_sample_offset_impression-03.png',
             type: 'envited-x:isMedia',
+            mimeType: 'image/png',
           },
           {
             path: 'media/bbox.geojson',
             type: 'envited-x:isMedia',
+            mimeType: 'application/x-geojson',
           },
           {
             path: 'media/roadNetwork.geojson',
             type: 'envited-x:isMedia',
+            mimeType: 'application/x-geojson',
           },
           {
             path: 'media/3d_preview/breakLines.json',
             type: 'envited-x:isMedia',
+            mimeType: 'application/json',
           },
           {
             path: 'media/3d_preview/junctions.json',
             type: 'envited-x:isMedia',
+            mimeType: 'application/json',
           },
           {
             path: 'media/3d_preview/laneSections.json',
             type: 'envited-x:isMedia',
+            mimeType: 'application/json',
           },
           {
             path: 'media/3d_preview/lanes.json',
             type: 'envited-x:isMedia',
+            mimeType: 'application/json',
           },
           {
             path: 'media/3d_preview/objects.json',
             type: 'envited-x:isMedia',
+            mimeType: 'application/json',
           },
           {
             path: 'media/3d_preview/refLine.json',
             type: 'envited-x:isMedia',
+            mimeType: 'application/json',
           },
           {
             path: 'media/3d_preview/roadMarks.json',
             type: 'envited-x:isMedia',
+            mimeType: 'application/json',
           },
           {
             path: 'media/3d_preview/roads.json',
             type: 'envited-x:isMedia',
+            mimeType: 'application/json',
           },
           {
             path: 'media/3d_preview/signals.json',
             type: 'envited-x:isMedia',
+            mimeType: 'application/json',
           },
           {
             path: 'validation-reports/TestfeldNiedersachsen_ALKS_ODR_sample_offset_openmsl_cb_xodr_QCReport.txt',
@@ -152,6 +165,7 @@ describe('common/asset/utils', () => {
           {
             path: 'media/TestfeldNiedersachsen_ALKS_ODR_sample_offset_impression-01.png',
             type: 'envited-x:isMedia',
+            mimeType: 'image/png',
           },
         ],
       }

--- a/apps/envited-x-data-space/common/asset/utils.ts
+++ b/apps/envited-x-data-space/common/asset/utils.ts
@@ -8,6 +8,7 @@ import {
   any,
   append,
   applySpec,
+  assoc,
   concat,
   equals,
   find,
@@ -36,6 +37,7 @@ import {
   MANIFEST_LINK_FILE_PATH,
   MANIFEST_LINK_MIME_TYPE,
   MANIFEST_REFERENCE,
+  MEDIA_DESCRIPTOR,
 } from './constants'
 import { AccessRole, ExtractedFileWithCID, Manifest, ManifestCategoryId, ManifestLink } from './types'
 
@@ -115,6 +117,7 @@ export const formatManifestLinkPath = replace('./', '')
 
 export const isRemoteUrl = startsWith('https://')
 export const isSelfHosted = includes('.envited-x.net')
+export const isMedia = equals(MEDIA_DESCRIPTOR)
 
 export const hasManifestThirdPartyLinks = (manifest: Manifest) =>
   pipe(
@@ -129,16 +132,24 @@ export const hasManifestThirdPartyLinks = (manifest: Manifest) =>
 
 export const getPathsFromManifestLinks = (links: ManifestLink[]) =>
   pipe(
-    map((link: ManifestLink) =>
-      !isRemoteUrl(pathOr('', MANIFEST_LINK_FILE_PATH)(link))
+    map((link: ManifestLink) => {
+      const fileType = path(MANIFEST_CATEGORY_ID)(link) as string
+      const fileData = !isRemoteUrl(pathOr('', MANIFEST_LINK_FILE_PATH)(link))
         ? {
             path: formatManifestLinkPath(pathOr('', MANIFEST_LINK_FILE_PATH)(link)),
-            type: path(MANIFEST_CATEGORY_ID)(link),
+            type: fileType,
           }
-        : null,
+        : null
+      if (fileData && isMedia(fileType)) {
+        const mimeType = pathOr('', MANIFEST_LINK_MIME_TYPE)(link)
+        return assoc('mimeType', mimeType)(fileData)
+      }
+
+      return fileData
+    }
     ),
     reject(isNil),
-  )(links) as { path: string; type: string }[]
+  )(links) as { path: string; type: string; mimeType?: string }[]
 
 export const getAllManifestLinksAndFormatPaths = (manifest: Manifest) =>
   pipe(

--- a/apps/envited-x-data-space/common/asset/utils.ts
+++ b/apps/envited-x-data-space/common/asset/utils.ts
@@ -212,12 +212,17 @@ export const _getAllFilenamesFromFiles =
   ({
     getFilenameFromFile,
   }: {
-    getFilenameFromFile: (path: string, category: ManifestCategoryId, arrayBuffer: ArrayBuffer) => Promise<ExtractedFileWithCID>
+    getFilenameFromFile: (
+      path: string,
+      category: ManifestCategoryId,
+      arrayBuffer: ArrayBuffer,
+    ) => Promise<ExtractedFileWithCID>
   }) =>
   async (files: { path: string; category: ManifestCategoryId; arrayBuffer: ArrayBuffer }[]) =>
     await Promise.all(
-      files.map(({ path, category, arrayBuffer }: { path: string; category: ManifestCategoryId; arrayBuffer: ArrayBuffer }) =>
-        getFilenameFromFile(path, category, arrayBuffer),
+      files.map(
+        ({ path, category, arrayBuffer }: { path: string; category: ManifestCategoryId; arrayBuffer: ArrayBuffer }) =>
+          getFilenameFromFile(path, category, arrayBuffer),
       ),
     )
 
@@ -237,7 +242,9 @@ export const _getPathsAndBuffersFromByteArray =
   }) =>
   async (byteArray: Uint8Array, files: { path: string; category: ManifestCategoryId }[]) =>
     await Promise.all(
-      files.map(({ path, category }: { path: string; category: ManifestCategoryId }) => getPathAndBufferFromFile(byteArray, path, category)),
+      files.map(({ path, category }: { path: string; category: ManifestCategoryId }) =>
+        getPathAndBufferFromFile(byteArray, path, category),
+      ),
     )
 
 export const getPathsAndBuffersFromByteArray = _getPathsAndBuffersFromByteArray({

--- a/apps/envited-x-data-space/common/asset/utils.ts
+++ b/apps/envited-x-data-space/common/asset/utils.ts
@@ -146,8 +146,7 @@ export const getPathsFromManifestLinks = (links: ManifestLink[]) =>
       }
 
       return fileData
-    }
-    ),
+    }),
     reject(isNil),
   )(links) as { path: string; type: string; mimeType?: string }[]
 

--- a/apps/envited-x-data-space/common/asset/utils.ts
+++ b/apps/envited-x-data-space/common/asset/utils.ts
@@ -37,9 +37,8 @@ import {
   MANIFEST_LINK_FILE_PATH,
   MANIFEST_LINK_MIME_TYPE,
   MANIFEST_REFERENCE,
-  MEDIA_DESCRIPTOR,
 } from './constants'
-import { AccessRole, ExtractedFileWithCID, Manifest, ManifestCategoryId, ManifestLink } from './types'
+import { AccessRole, ExtractedFile, ExtractedFileWithCID, Manifest, ManifestCategoryId, ManifestLink } from './types'
 
 export const _createFilename =
   ({ raw, sha256, CID }: { raw: any; sha256: Hasher<'sha2-256', 18>; CID: any }) =>
@@ -117,7 +116,7 @@ export const formatManifestLinkPath = replace('./', '')
 
 export const isRemoteUrl = startsWith('https://')
 export const isSelfHosted = includes('.envited-x.net')
-export const isMedia = equals(MEDIA_DESCRIPTOR)
+export const isMedia = equals(ManifestCategoryId.envitedXIsMedia)
 
 export const hasManifestThirdPartyLinks = (manifest: Manifest) =>
   pipe(
@@ -133,14 +132,14 @@ export const hasManifestThirdPartyLinks = (manifest: Manifest) =>
 export const getPathsFromManifestLinks = (links: ManifestLink[]) =>
   pipe(
     map((link: ManifestLink) => {
-      const fileType = path(MANIFEST_CATEGORY_ID)(link) as string
+      const category = path(MANIFEST_CATEGORY_ID)(link) as ManifestCategoryId
       const fileData = !isRemoteUrl(pathOr('', MANIFEST_LINK_FILE_PATH)(link))
         ? {
             path: formatManifestLinkPath(pathOr('', MANIFEST_LINK_FILE_PATH)(link)),
-            type: fileType,
+            category: category,
           }
         : null
-      if (fileData && isMedia(fileType)) {
+      if (fileData && isMedia(category)) {
         const mimeType = pathOr('', MANIFEST_LINK_MIME_TYPE)(link)
         return assoc('mimeType', mimeType)(fileData)
       }
@@ -148,7 +147,7 @@ export const getPathsFromManifestLinks = (links: ManifestLink[]) =>
       return fileData
     }),
     reject(isNil),
-  )(links) as { path: string; type: string; mimeType?: string }[]
+  )(links) as { path: string; category: ManifestCategoryId; mimeType?: string }[]
 
 export const getAllManifestLinksAndFormatPaths = (manifest: Manifest) =>
   pipe(
@@ -163,9 +162,9 @@ export const _getPathAndBufferFromFile =
   }: {
     getArrayBufferFromByteArray: (byteArray: Uint8Array, filename: string) => Promise<ArrayBuffer>
   }) =>
-  async (byteArray: Uint8Array, path: string, type: string) => ({
+  async (byteArray: Uint8Array, path: string, category: ManifestCategoryId) => ({
     path,
-    type,
+    category,
     arrayBuffer: await getArrayBufferFromByteArray(byteArray, path),
   })
 
@@ -195,12 +194,12 @@ export const predetermineCID = async (array: Uint8Array) => {
 
 export const _getFilenameFromFile =
   ({ predetermineCID }: { predetermineCID: (byteArray: Uint8Array) => Promise<string> }) =>
-  async (path: string, type: string, arrayBuffer: ArrayBuffer): Promise<ExtractedFileWithCID> => {
+  async (path: string, category: ManifestCategoryId, arrayBuffer: ArrayBuffer): Promise<ExtractedFileWithCID> => {
     const cid = await predetermineCID(new Uint8Array(arrayBuffer))
     return {
       cid,
       path,
-      type,
+      category,
       arrayBuffer,
     }
   }
@@ -213,12 +212,12 @@ export const _getAllFilenamesFromFiles =
   ({
     getFilenameFromFile,
   }: {
-    getFilenameFromFile: (path: string, type: string, arrayBuffer: ArrayBuffer) => Promise<ExtractedFileWithCID>
+    getFilenameFromFile: (path: string, category: ManifestCategoryId, arrayBuffer: ArrayBuffer) => Promise<ExtractedFileWithCID>
   }) =>
-  async (files: { path: string; type: string; arrayBuffer: ArrayBuffer }[]) =>
+  async (files: { path: string; category: ManifestCategoryId; arrayBuffer: ArrayBuffer }[]) =>
     await Promise.all(
-      files.map(({ path, type, arrayBuffer }: { path: string; type: string; arrayBuffer: ArrayBuffer }) =>
-        getFilenameFromFile(path, type, arrayBuffer),
+      files.map(({ path, category, arrayBuffer }: { path: string; category: ManifestCategoryId; arrayBuffer: ArrayBuffer }) =>
+        getFilenameFromFile(path, category, arrayBuffer),
       ),
     )
 
@@ -233,12 +232,12 @@ export const _getPathsAndBuffersFromByteArray =
     getPathAndBufferFromFile: (
       byteArray: Uint8Array,
       path: string,
-      type: string,
-    ) => Promise<{ path: string; type: string; arrayBuffer: ArrayBuffer }>
+      category: ManifestCategoryId,
+    ) => Promise<ExtractedFile>
   }) =>
-  async (byteArray: Uint8Array, files: { path: string; type: string }[]) =>
+  async (byteArray: Uint8Array, files: { path: string; category: ManifestCategoryId }[]) =>
     await Promise.all(
-      files.map(({ path, type }: { path: string; type: string }) => getPathAndBufferFromFile(byteArray, path, type)),
+      files.map(({ path, category }: { path: string; category: ManifestCategoryId }) => getPathAndBufferFromFile(byteArray, path, category)),
     )
 
 export const getPathsAndBuffersFromByteArray = _getPathsAndBuffersFromByteArray({
@@ -251,8 +250,8 @@ export const _getFilesAsPathAndByteArrayFromManifest =
   }: {
     getPathsAndBuffersFromByteArray: (
       byteArray: Uint8Array,
-      files: { path: string; type: string }[],
-    ) => Promise<{ path: string; type: string; arrayBuffer: ArrayBuffer }[]>
+      files: { path: string; category: ManifestCategoryId }[],
+    ) => Promise<ExtractedFile[]>
   }) =>
   async (byteArray: Uint8Array, manifest: Manifest) => {
     const { owner, registeredUser, publicUser } = getFilesGroupedByAccessRoles(manifest)

--- a/apps/envited-x-data-space/common/asset/utils.ts
+++ b/apps/envited-x-data-space/common/asset/utils.ts
@@ -116,7 +116,6 @@ export const formatManifestLinkPath = replace('./', '')
 
 export const isRemoteUrl = startsWith('https://')
 export const isSelfHosted = includes('.envited-x.net')
-export const isMedia = equals(ManifestCategoryId.envitedXIsMedia)
 
 export const hasManifestThirdPartyLinks = (manifest: Manifest) =>
   pipe(
@@ -139,7 +138,7 @@ export const getPathsFromManifestLinks = (links: ManifestLink[]) =>
             category: category,
           }
         : null
-      if (fileData && isMedia(category)) {
+      if (fileData) {
         const mimeType = pathOr('', MANIFEST_LINK_MIME_TYPE)(link)
         return assoc('mimeType', mimeType)(fileData)
       }

--- a/apps/envited-x-data-space/common/asset/validateAndCreateMetadata.test.ts
+++ b/apps/envited-x-data-space/common/asset/validateAndCreateMetadata.test.ts
@@ -20,15 +20,18 @@ describe('common/asset/validateAndCreateMetadata', () => {
         {
           path: 'PATH',
           arrayBuffer: 'FILE_BUFFER',
-          cid: 'DISPLAY_HASH',
+          cid: 'FILE_CID',
           type: 'envited-x:isMedia',
+          mimeType: 'application/json',
         },
         {
           path: 'PATH',
           arrayBuffer: 'FILE_BUFFER',
-          cid: 'FILE_CID',
+          cid: 'DISPLAY_HASH',
           type: 'envited-x:isMedia',
+          mimeType: 'image/png',
         },
+        
       ]) as any
       const getFilesAsPathAndByteArrayFromManifestStub = jest.fn().mockResolvedValue({
         owner: [
@@ -108,14 +111,16 @@ describe('common/asset/validateAndCreateMetadata', () => {
           {
             path: 'PATH',
             arrayBuffer: 'FILE_BUFFER',
-            cid: 'DISPLAY_HASH',
+            cid: 'FILE_CID',
             type: 'envited-x:isMedia',
+            mimeType: 'application/json',
           },
           {
             path: 'PATH',
             arrayBuffer: 'FILE_BUFFER',
-            cid: 'FILE_CID',
+            cid: 'DISPLAY_HASH',
             type: 'envited-x:isMedia',
+            mimeType: 'image/png',
           },
         ],
       })

--- a/apps/envited-x-data-space/common/asset/validateAndCreateMetadata.test.ts
+++ b/apps/envited-x-data-space/common/asset/validateAndCreateMetadata.test.ts
@@ -31,7 +31,6 @@ describe('common/asset/validateAndCreateMetadata', () => {
           type: 'envited-x:isMedia',
           mimeType: 'image/png',
         },
-        
       ]) as any
       const getFilesAsPathAndByteArrayFromManifestStub = jest.fn().mockResolvedValue({
         owner: [

--- a/apps/envited-x-data-space/common/asset/validateAndCreateMetadata.ts
+++ b/apps/envited-x-data-space/common/asset/validateAndCreateMetadata.ts
@@ -1,5 +1,21 @@
 import fs from 'fs'
-import { all, and, compose, equals, filter, find, includes, keys, omit, path, pathOr, pipe, prop, propEq, propOr } from 'ramda'
+import {
+  all,
+  and,
+  compose,
+  equals,
+  filter,
+  find,
+  includes,
+  keys,
+  omit,
+  path,
+  pathOr,
+  pipe,
+  prop,
+  propEq,
+  propOr,
+} from 'ramda'
 import ValidationReport from 'rdf-validate-shacl/src/validation-report'
 
 import { db } from '../database/queries'
@@ -261,7 +277,9 @@ export const _validateAndCreateMetadata =
         fileSize: byteArray.length,
       }
 
-      const displayUri = find(and(propEq(MEDIA_DESCRIPTOR, 'type'), compose(includes('image'), propOr('', 'mimeType'))))(visualizationFiles) as ExtractedFileWithCID
+      const displayUri = find(
+        and(propEq(MEDIA_DESCRIPTOR, 'type'), compose(includes('image'), propOr('', 'mimeType'))),
+      )(visualizationFiles) as ExtractedFileWithCID
       const displayObject = {
         cid: displayUri.cid,
         fileSize: displayUri.arrayBuffer.byteLength,

--- a/apps/envited-x-data-space/common/asset/validateAndCreateMetadata.ts
+++ b/apps/envited-x-data-space/common/asset/validateAndCreateMetadata.ts
@@ -1,5 +1,5 @@
 import fs from 'fs'
-import { all, equals, filter, find, keys, omit, path, pathOr, pipe, prop, propEq } from 'ramda'
+import { all, and, compose, equals, filter, find, includes, keys, omit, path, pathOr, pipe, prop, propEq, propOr } from 'ramda'
 import ValidationReport from 'rdf-validate-shacl/src/validation-report'
 
 import { db } from '../database/queries'
@@ -9,7 +9,7 @@ import { extractAddressFromDid, formatAssetUri } from '../utils'
 import { validateShaclDataWithSchema } from '../validator'
 import { CONTEXT_DROP_SCHEMAS, SCHEMA_MAP } from '../validator/shacl/shacl.constants'
 import { ValidationSchema } from '../validator/shacl/shacl.types'
-import { MANIFEST_FILE, MANIFEST_LICENSE, MANIFEST_LICENSE_PATH } from './constants'
+import { MANIFEST_FILE, MANIFEST_LICENSE, MANIFEST_LICENSE_PATH, MEDIA_DESCRIPTOR } from './constants'
 import { createModifiedManifest } from './createModifiedManifest'
 import { createTokenMetadata } from './createTokenMetadata'
 import { ExtractedFile, ExtractedFileWithCID, Manifest, ManifestExtractedFiles } from './types'
@@ -261,7 +261,7 @@ export const _validateAndCreateMetadata =
         fileSize: byteArray.length,
       }
 
-      const displayUri = find(propEq('envited-x:isMedia', 'type'))(visualizationFiles) as ExtractedFileWithCID
+      const displayUri = find(and(propEq(MEDIA_DESCRIPTOR, 'type'), compose(includes('image'), propOr('', 'mimeType'))))(visualizationFiles) as ExtractedFileWithCID
       const displayObject = {
         cid: displayUri.cid,
         fileSize: displayUri.arrayBuffer.byteLength,

--- a/apps/envited-x-data-space/common/asset/validateAndCreateMetadata.ts
+++ b/apps/envited-x-data-space/common/asset/validateAndCreateMetadata.ts
@@ -25,10 +25,10 @@ import { extractAddressFromDid, formatAssetUri } from '../utils'
 import { validateShaclDataWithSchema } from '../validator'
 import { CONTEXT_DROP_SCHEMAS, SCHEMA_MAP } from '../validator/shacl/shacl.constants'
 import { ValidationSchema } from '../validator/shacl/shacl.types'
-import { MANIFEST_FILE, MANIFEST_LICENSE, MANIFEST_LICENSE_PATH, MEDIA_DESCRIPTOR } from './constants'
+import { MANIFEST_FILE, MANIFEST_LICENSE, MANIFEST_LICENSE_PATH } from './constants'
 import { createModifiedManifest } from './createModifiedManifest'
 import { createTokenMetadata } from './createTokenMetadata'
-import { ExtractedFile, ExtractedFileWithCID, Manifest, ManifestExtractedFiles } from './types'
+import { ExtractedFile, ExtractedFileWithCID, Manifest, ManifestCategoryId, ManifestExtractedFiles } from './types'
 import {
   createFilename,
   getAllFilenamesFromFiles,
@@ -239,7 +239,7 @@ export const _validateAndCreateMetadata =
       manifest: Manifest,
     ) => Promise<ManifestExtractedFiles>
     getAllFilenamesFromFiles: (
-      extractedFiles: { path: string; type: string; arrayBuffer: ArrayBuffer }[],
+      extractedFiles: { path: string; category: ManifestCategoryId; arrayBuffer: ArrayBuffer }[],
     ) => Promise<ExtractedFileWithCID[]>
     db: Database
   }) =>
@@ -278,7 +278,7 @@ export const _validateAndCreateMetadata =
       }
 
       const displayUri = find(
-        and(propEq(MEDIA_DESCRIPTOR, 'type'), compose(includes('image'), propOr('', 'mimeType'))),
+        and(propEq(ManifestCategoryId.envitedXIsMedia, 'type'), compose(includes('image'), propOr('', 'mimeType'))),
       )(visualizationFiles) as ExtractedFileWithCID
       const displayObject = {
         cid: displayUri.cid,

--- a/apps/envited-x-data-space/common/utils/index.ts
+++ b/apps/envited-x-data-space/common/utils/index.ts
@@ -41,4 +41,5 @@ export {
   capitalize,
   removeKeywords,
   kebabToCamelCase,
+  handleImageLoadError,
 } from './utils'

--- a/apps/envited-x-data-space/common/utils/utils.ts
+++ b/apps/envited-x-data-space/common/utils/utils.ts
@@ -186,3 +186,16 @@ export const kebabToCamelCase = (str: string): string => {
     })
     .join('')
 }
+
+export const handleImageLoadError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
+  const target = e.target as HTMLImageElement
+  // Prevent infinite loop if fallback also fails
+  if (!target.src.includes('/ASCS_logo_envited-X_colour_alex.png')) {
+    target.src = '/ASCS_logo_envited-X_colour_alex.png'
+    // Apply styling to center the image at 50% size and opacity
+    target.style.objectFit = 'contain'
+    target.style.maxWidth = '50%'
+    target.style.maxHeight = '50%'
+    target.style.opacity = '0.5'
+  }
+}

--- a/apps/envited-x-data-space/common/validator/shacl/shacl.types.ts
+++ b/apps/envited-x-data-space/common/validator/shacl/shacl.types.ts
@@ -4,7 +4,7 @@ export enum ContentType {
 }
 
 export enum Schema {
-  automotiveSimulator = 'automotive-simulater',
+  automotiveSimulator = 'automotive-simulator',
   environmentModel = 'environment-model',
   envitedX = 'envited-x',
   general = 'general',

--- a/apps/envited-x-data-space/modules/Asset/Asset.tsx
+++ b/apps/envited-x-data-space/modules/Asset/Asset.tsx
@@ -15,6 +15,7 @@ import {
   formatItemName,
   formatSectionName,
   getAssetType,
+  handleImageLoadError,
   kebabToCamelCase,
   removeKeywords,
 } from '../../common/utils'
@@ -53,7 +54,7 @@ export const Asset: FC<AssetProps> = ({ token: { token } }) => {
     return Object.values(obj).some(value => typeof value === 'object' && value !== null)
   }
 
-  const renderNestedProperties = (properties: any, section: string, level: number = 0) => {
+  const renderNestedProperties = (properties: any, section: string, level = 0) => {
     return Object.entries(properties).map(([key, value]) => {
       // Handle arrays by joining them with commas
       if (Array.isArray(value)) {
@@ -100,8 +101,13 @@ export const Asset: FC<AssetProps> = ({ token: { token } }) => {
       <div>
         <div className="lg:grid lg:grid-cols-7 lg:grid-rows-1 lg:gap-x-8 lg:gap-y-10 xl:gap-x-16">
           <div className="lg:col-span-4 lg:row-end-1">
-            <div className="aspect-h-3 aspect-w-4 overflow-hidden rounded-lg bg-gray-100">
-              <img src={token.displayUri} alt={token.name} className="object-cover object-center" />
+            <div className="aspect-h-3 aspect-w-4 overflow-hidden rounded-lg bg-gray-100 flex justify-center items-center min-h-48 lg:min-h-96">
+              <img
+                src={token.displayUri}
+                alt={token.name}
+                className="object-cover object-center"
+                onError={handleImageLoadError}
+              />
             </div>
           </div>
 
@@ -150,7 +156,7 @@ export const Asset: FC<AssetProps> = ({ token: { token } }) => {
                               return ''
                             }
                             return (
-                              <li>
+                              <li key={key}>
                                 <strong>{pipe(formatSectionName, formatItemName)(key as string) as string}:</strong>{' '}
                                 {value as string}
                               </li>

--- a/apps/envited-x-data-space/modules/Assets/Assets.tsx
+++ b/apps/envited-x-data-space/modules/Assets/Assets.tsx
@@ -7,6 +7,7 @@ import { map, propOr } from 'ramda'
 import { FC, Fragment, useState } from 'react'
 
 import { Token } from '../../common/types'
+import { handleImageLoadError } from '../../common/utils'
 
 const filters = [
   {
@@ -174,11 +175,12 @@ export const Assets: FC<AssetsProps> = ({ items }) => {
                 key={id}
                 className="group relative flex flex-col overflow-hidden rounded-lg border border-gray-200 bg-white"
               >
-                <div className="aspect-h-3 aspect-w-4 bg-gray-200 sm:aspect-none group-hover:opacity-75 sm:h-48">
+                <div className="aspect-h-3 aspect-w-4 bg-gray-200 sm:aspect-none group-hover:opacity-75 sm:h-48 flex justify-center items-center">
                   <img
                     src={displayUri}
                     alt={name}
-                    className="h-48 w-full object-cover object-center sm:h-48 sm:w-full"
+                    className="h-48 w-full object-cover object-center sm:h-48 sm:w-full "
+                    onError={handleImageLoadError}
                   />
                 </div>
                 <div className="flex flex-1 flex-col space-y-2 p-4">

--- a/apps/envited-x-data-space/modules/Assets/DashboardAssets.tsx
+++ b/apps/envited-x-data-space/modules/Assets/DashboardAssets.tsx
@@ -8,6 +8,7 @@ import { FC } from 'react'
 import { ROUTES } from '../../common/constants/routes'
 import { useTranslation } from '../../common/i18n'
 import { Token } from '../../common/types'
+import { handleImageLoadError } from '../../common/utils'
 
 interface AssetsProps {
   tokens: Token[]
@@ -33,8 +34,8 @@ export const DashboardAssets: FC<AssetsProps> = ({ tokens }) => {
             key={id}
             className="group relative flex flex-col overflow-hidden rounded-lg border border-gray-200 bg-white"
           >
-            <div className="aspect-h-3 aspect-w-4 bg-gray-200 sm:aspect-none group-hover:opacity-75 sm:h-48">
-              <img src={displayUri} alt={name} className="h-48 w-full object-cover object-center sm:h-48 sm:w-full" />
+            <div className="aspect-h-3 aspect-w-4 bg-gray-200 sm:aspect-none group-hover:opacity-75 sm:h-48 flex justify-center items-center">
+              <img src={displayUri} alt={name} className="h-48 w-full object-cover object-center sm:h-48 sm:w-full" onError={handleImageLoadError}/>
             </div>
             <div className="flex flex-1 flex-col space-y-2 p-4">
               <p className="text-sm italic text-gray-500">{id}</p>

--- a/apps/envited-x-data-space/modules/Assets/DashboardAssets.tsx
+++ b/apps/envited-x-data-space/modules/Assets/DashboardAssets.tsx
@@ -35,7 +35,12 @@ export const DashboardAssets: FC<AssetsProps> = ({ tokens }) => {
             className="group relative flex flex-col overflow-hidden rounded-lg border border-gray-200 bg-white"
           >
             <div className="aspect-h-3 aspect-w-4 bg-gray-200 sm:aspect-none group-hover:opacity-75 sm:h-48 flex justify-center items-center">
-              <img src={displayUri} alt={name} className="h-48 w-full object-cover object-center sm:h-48 sm:w-full" onError={handleImageLoadError}/>
+              <img
+                src={displayUri}
+                alt={name}
+                className="h-48 w-full object-cover object-center sm:h-48 sm:w-full"
+                onError={handleImageLoadError}
+              />
             </div>
             <div className="flex flex-1 flex-col space-y-2 p-4">
               <p className="text-sm italic text-gray-500">{id}</p>

--- a/apps/envited-x-data-space/modules/Member/Member.tsx
+++ b/apps/envited-x-data-space/modules/Member/Member.tsx
@@ -7,7 +7,7 @@ import React, { FC, Fragment } from 'react'
 
 import { useTranslation } from '../../common/i18n'
 import { Profile, Token } from '../../common/types'
-import { getImageUrl } from '../../common/utils'
+import { getImageUrl, handleImageLoadError } from '../../common/utils'
 
 interface MemberProps {
   member: Profile
@@ -46,7 +46,7 @@ export const Member: FC<MemberProps> = ({ member, tokens }) => {
                 />
               </div>
 
-              <div className="aspect-h-3 aspect-w-4 overflow-hidden rounded-lg bg-gray-100">
+              <div className="aspect-h-3 aspect-w-4 overflow-hidden rounded-lg bg-gray-100 flex justify-center items-center min-h-48 lg:min-h-96">
                 {!isNil(propOr('', 'logo')(member)) && (
                   <img
                     src={getImageUrl(propOr('', 'logo')(member))}
@@ -157,11 +157,12 @@ export const Member: FC<MemberProps> = ({ member, tokens }) => {
                 key={id}
                 className="group relative flex flex-col overflow-hidden rounded-lg border border-gray-200 bg-white"
               >
-                <div className="aspect-h-3 aspect-w-4 bg-gray-200 sm:aspect-none group-hover:opacity-75 sm:h-48">
+                <div className="aspect-h-3 aspect-w-4 bg-gray-200 sm:aspect-none group-hover:opacity-75 sm:h-48 flex justify-center items-center">
                   <img
                     src={displayUri}
                     alt={name}
                     className="h-48 w-full object-cover object-center sm:h-48 sm:w-full"
+                    onError={handleImageLoadError}
                   />
                 </div>
                 <div className="flex flex-1 flex-col space-y-2 p-4">


### PR DESCRIPTION
# Scope

When creating the tokenMetadata it did not check whether the displayUri was actually an image and could therefore be incorrect. This PR fixes this.

# Work done
- Check for mimetype and grab media only if it has an image mimetype
- Show a placeholder when image can't be loaded